### PR TITLE
fix: update-set-from rules are not applied correctly

### DIFF
--- a/src/kyselyAccessControl.ts
+++ b/src/kyselyAccessControl.ts
@@ -501,7 +501,7 @@ export const createAccessControlPlugin = <KyselyDatabase = unknown>(
 
         const guardResult = fullGuard.table(
           from.table,
-          StatementType.Update,
+          StatementType.Select,
           TableUsageContext.TableInJoin
         );
 


### PR DESCRIPTION
Context:

1. Select on table `person` and table `rsvp` is allowed
2. Update on table `rsvp` is allowed (not `person`)
3. Update table `rsvp` set X from `person` failed with:

```
✗ kysely-grants > should enforce access control on update-set-from query [2.17ms]

src/kyselyAccessControl.test.ts:
78 | export const throwIfDenyWithReason = (
79 |   guardResult: ColumnGuardResult | TableGuardResult<unknown>,
80 |   coreErrorString: string
81 | ): void => {
82 |   if (guardResult === Deny) {
83 |     throw new Error(coreErrorString);
                   ^
error: JOIN denied on table person
      at throwIfDenyWithReason (/Users/leonidkoftun/projects/kysely-access-control/src/kyselyAccessControl.ts:83:15)
      at <anonymous> (/Users/leonidkoftun/projects/kysely-access-control/src/kyselyAccessControl.ts:508:9)
      at map (1:11)
      at transformFrom (/Users/leonidkoftun/projects/kysely-access-control/src/kyselyAccessControl.ts:495:35)
      at transformNode (/Users/leonidkoftun/projects/kysely-access-control/node_modules/kysely/dist/esm/operation-node/operation-node-transformer.js:128:26)
      at transformUpdateQuery (/Users/leonidkoftun/projects/kysely-access-control/node_modules/kysely/dist/esm/operation-node/operation-node-transformer.js:361:24)
      at transformNode (/Users/leonidkoftun/projects/kysely-access-control/node_modules/kysely/dist/esm/operation-node/operation-node-transformer.js:128:26)
      at transformQuery (/Users/leonidkoftun/projects/kysely-access-control/node_modules/kysely/dist/esm/query-executor/query-executor-base.js:16:44)
      at compile (/Users/leonidkoftun/projects/kysely-access-control/node_modules/kysely/dist/esm/query-builder/update-query-builder.js:269:55)
      at <anonymous> (/Users/leonidkoftun/projects/kysely-access-control/src/kyselyAccessControl.test.ts:727:8)
 ```
 
 Again, this is a lazy fix by cursor for my specific tests. Please have a closer look if the previous condition was intentional. Maybe I'm missing another test case.